### PR TITLE
Support anon subs better

### DIFF
--- a/podgen
+++ b/podgen
@@ -335,6 +335,15 @@ sub main
             }
 
             #
+            # Look for anonymous subroutines
+            #
+
+            if (/\bsub\s*\{/)
+            {
+                push @Subs, { name => undef, params => [] };
+            }
+
+            #
             # Look for shifted parameters.
             #
 
@@ -426,6 +435,7 @@ sub main
 
         if (eof)
         {
+            @Subs = grep { $_->{name} } @Subs;
             write_documentation;
 
             #


### PR DESCRIPTION
Possibly the patch is self-evident, but the idea is to detect when
an anon sub is being declared, and stick a placeholder entry in @Subs.
These are distinguished by having name => undef.

That way, we don't have to change any of the code that accumulates sub
metadata (for example parameters). We can accumulate it, same as always,
but then filter out anon subs before generating our documentation.

A previous iteration tried to make metadata accumulation smarter, by
checking whether @Subs had any entries yet (since the original error was
trying to access @Subs[-1] when @Subs was length 0). But this wasn't
quite smart enough - it only handled cases where no named subs had been
declared yet. If a named sub _had_ been declared, it would get all the
metadata for the anon subs following it, which is clearly wrong! The
easiest and most logical fix is to acknowledge anon subs, but throw them
away later.
